### PR TITLE
adding omit call to results

### DIFF
--- a/tabby-fp/src/commonMain/kotlin/com/sksamuel/tabby/results/results.kt
+++ b/tabby-fp/src/commonMain/kotlin/com/sksamuel/tabby/results/results.kt
@@ -50,6 +50,8 @@ fun <A> Result<A>.failIfNot(p: (A) -> Boolean, exception: Exception) =
  */
 fun Result.Companion.unit() = Unit.success()
 
+fun <A> Result<A>.omit(): Result<Unit> = this.flatMap { Unit.success() }
+
 fun <A> Result<Result<A>>.flatten(): Result<A> = this.fold({ it }, { it.failure() })
 
 fun <A> Result<A>.exceptionOrThrow() = this.exceptionOrNull() ?: throw IllegalStateException("Expected exception")


### PR DESCRIPTION
Adding the `omit` that removes the object from a result type.