### PR TITLE
enhance the safety of catching

### DIFF
--- a/tabby-fp/src/main/kotlin/com/sksamuel/tabby/results/catching.kt
+++ b/tabby-fp/src/main/kotlin/com/sksamuel/tabby/results/catching.kt
@@ -1,9 +1,24 @@
 package com.sksamuel.tabby.results
 
+import io.ktor.utils.io.CancellationException
+import kotlinx.coroutines.TimeoutCancellationException
+
 interface Catching {
    fun <A> Result<A>.bind() = this.getOrThrow()
 }
 
 inline fun <R> catching(f: Catching.() -> R): Result<R> = runCatching {
    object : Catching {}.f()
+}.onFailure { throwable ->
+   when (throwable) {
+      is VirtualMachineError, // OutOfMemory and the like
+      is ThreadDeath, // deprecated but still possibly thrown by old libraries etc
+      is LinkageError, // dependency incompatibilities basically
+      is CancellationException, // should never be caught as doing so breaks coroutines
+      is TimeoutCancellationException, // currently a subclass of the above but that will change
+      is InterruptedException // same as above but threads
+      -> {
+         throw throwable // never catch the above, always rethrow them
+      }
+   }
 }


### PR DESCRIPTION
enhance the safety of catching by rethrowing things that should never be caught (such as Errors like OutOfMemory, CancellationException etc)