### PR TITLE
Fix Result.mapN returning wrong failure on d/e/f

### DIFF
--- a/src/main/kotlin/com/sksamuel/tabby/results/mapn.kt
+++ b/src/main/kotlin/com/sksamuel/tabby/results/mapn.kt
@@ -47,7 +47,7 @@ inline fun <A, B, C, D, R> Result.Companion.mapN(
    if (a.isFailure) return a as Result<R>
    if (b.isFailure) return b as Result<R>
    if (c.isFailure) return c as Result<R>
-   if (d.isFailure) return c as Result<R>
+   if (d.isFailure) return d as Result<R>
    return fn(a.getOrThrow(), b.getOrThrow(), c.getOrThrow(), d.getOrThrow()).success()
 }
 
@@ -67,8 +67,8 @@ inline fun <A, B, C, D, E, R> Result.Companion.mapN(
    if (a.isFailure) return a as Result<R>
    if (b.isFailure) return b as Result<R>
    if (c.isFailure) return c as Result<R>
-   if (d.isFailure) return c as Result<R>
-   if (e.isFailure) return c as Result<R>
+   if (d.isFailure) return d as Result<R>
+   if (e.isFailure) return e as Result<R>
    return fn(a.getOrThrow(), b.getOrThrow(), c.getOrThrow(), d.getOrThrow(), e.getOrThrow()).success()
 }
 
@@ -89,8 +89,8 @@ inline fun <A, B, C, D, E, F, R> Result.Companion.mapN(
    if (a.isFailure) return a as Result<R>
    if (b.isFailure) return b as Result<R>
    if (c.isFailure) return c as Result<R>
-   if (d.isFailure) return c as Result<R>
-   if (e.isFailure) return c as Result<R>
-   if (f.isFailure) return c as Result<R>
+   if (d.isFailure) return d as Result<R>
+   if (e.isFailure) return e as Result<R>
+   if (f.isFailure) return f as Result<R>
    return fn(a.getOrThrow(), b.getOrThrow(), c.getOrThrow(), d.getOrThrow(), e.getOrThrow(), f.getOrThrow()).success()
 }

--- a/src/test/kotlin/com/sksamuel/tabby/results/MapNTest.kt
+++ b/src/test/kotlin/com/sksamuel/tabby/results/MapNTest.kt
@@ -1,0 +1,123 @@
+package com.sksamuel.tabby.results
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class MapNTest : FunSpec() {
+   init {
+
+      test("mapN2 should return success when all inputs succeed") {
+         Result.mapN(Result.success(1), Result.success(2)) { a, b -> a + b }
+            .getOrThrow() shouldBe 3
+      }
+
+      test("mapN3 should return success when all inputs succeed") {
+         Result.mapN(Result.success(1), Result.success(2), Result.success(3)) { a, b, c -> a + b + c }
+            .getOrThrow() shouldBe 6
+      }
+
+      test("mapN4 should return success when all inputs succeed") {
+         Result.mapN(
+            Result.success(1),
+            Result.success(2),
+            Result.success(3),
+            Result.success(4),
+         ) { a, b, c, d -> a + b + c + d }.getOrThrow() shouldBe 10
+      }
+
+      test("mapN5 should return success when all inputs succeed") {
+         Result.mapN(
+            Result.success(1),
+            Result.success(2),
+            Result.success(3),
+            Result.success(4),
+            Result.success(5),
+         ) { a, b, c, d, e -> a + b + c + d + e }.getOrThrow() shouldBe 15
+      }
+
+      test("mapN6 should return success when all inputs succeed") {
+         Result.mapN(
+            Result.success(1),
+            Result.success(2),
+            Result.success(3),
+            Result.success(4),
+            Result.success(5),
+            Result.success(6),
+         ) { a, b, c, d, e, f -> a + b + c + d + e + f }.getOrThrow() shouldBe 21
+      }
+
+      test("mapN4 should propagate the failing argument's exception") {
+         val expected = RuntimeException("d failed")
+         val actual = Result.mapN(
+            Result.success(1),
+            Result.success(2),
+            Result.success(3),
+            Result.failure<Int>(expected),
+         ) { a, b, c, d -> a + b + c + d }.exceptionOrNull()
+         actual shouldBe expected
+      }
+
+      test("mapN5 should propagate the failing argument's exception (d)") {
+         val expected = RuntimeException("d failed")
+         val actual = Result.mapN(
+            Result.success(1),
+            Result.success(2),
+            Result.success(3),
+            Result.failure<Int>(expected),
+            Result.success(5),
+         ) { a, b, c, d, e -> a + b + c + d + e }.exceptionOrNull()
+         actual shouldBe expected
+      }
+
+      test("mapN5 should propagate the failing argument's exception (e)") {
+         val expected = RuntimeException("e failed")
+         val actual = Result.mapN(
+            Result.success(1),
+            Result.success(2),
+            Result.success(3),
+            Result.success(4),
+            Result.failure<Int>(expected),
+         ) { a, b, c, d, e -> a + b + c + d + e }.exceptionOrNull()
+         actual shouldBe expected
+      }
+
+      test("mapN6 should propagate the failing argument's exception (d)") {
+         val expected = RuntimeException("d failed")
+         val actual = Result.mapN(
+            Result.success(1),
+            Result.success(2),
+            Result.success(3),
+            Result.failure<Int>(expected),
+            Result.success(5),
+            Result.success(6),
+         ) { a, b, c, d, e, f -> a + b + c + d + e + f }.exceptionOrNull()
+         actual shouldBe expected
+      }
+
+      test("mapN6 should propagate the failing argument's exception (e)") {
+         val expected = RuntimeException("e failed")
+         val actual = Result.mapN(
+            Result.success(1),
+            Result.success(2),
+            Result.success(3),
+            Result.success(4),
+            Result.failure<Int>(expected),
+            Result.success(6),
+         ) { a, b, c, d, e, f -> a + b + c + d + e + f }.exceptionOrNull()
+         actual shouldBe expected
+      }
+
+      test("mapN6 should propagate the failing argument's exception (f)") {
+         val expected = RuntimeException("f failed")
+         val actual = Result.mapN(
+            Result.success(1),
+            Result.success(2),
+            Result.success(3),
+            Result.success(4),
+            Result.success(5),
+            Result.failure<Int>(expected),
+         ) { a, b, c, d, e, f -> a + b + c + d + e + f }.exceptionOrNull()
+         actual shouldBe expected
+      }
+   }
+}


### PR DESCRIPTION
## Summary

In the 4-, 5-, and 6-arity `Result.Companion.mapN` overloads in `results/mapn.kt`, a failure in `d`, `e`, or `f` returned `c`'s value instead — a copy-paste error.

This has two visible effects:
- **Wrong exception surfaced.** When `c` is also a failure, callers see `c`'s exception even though `d`/`e`/`f` is the one that failed (failures are masked).
- **Unsafe cast over a Success.** When `c` is a success but `d`/`e`/`f` is a failure, the function returns `c as Result<R>` — a successful `Result<C>` cast to `Result<R>`. The cast itself doesn't throw (Result is a value class with erased generics), but downstream `.getOrThrow()` will hand back a `C` typed as `R`, leading to a delayed `ClassCastException` or silent type confusion.

The sibling `Either.mapN` (`either/mapn.kt`) and `Nulls.mapN` (`nulls/mapn.kt`) overloads are correct, so this is isolated to the `Result` variants.

```diff
-   if (d.isFailure) return c as Result<R>
+   if (d.isFailure) return d as Result<R>
```

Same pattern at three arities; full diff in the commit.

## Test plan

- [x] New `MapNTest` covers success and per-argument failure paths for arities 2–6
- [x] Verified the new tests fail on `master` (6 of 11 fail) and pass on this branch
- [x] `./gradlew test` is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)