### PR TITLE
Fix Either.sequence filtering by erased type parameters

### DIFF
--- a/src/main/kotlin/com/sksamuel/tabby/either/sequence.kt
+++ b/src/main/kotlin/com/sksamuel/tabby/either/sequence.kt
@@ -1,12 +1,16 @@
 package com.sksamuel.tabby.either
 
 /**
- * Gather's together Either's effects.
+ * Gathers together Either's effects.
  *
- * Specifically, returns the first [Either.Left], or a List of all [Either.Right]s.
+ * If any element is an [Either.Left], returns a [Either.Left] containing all the left values.
+ * Otherwise returns an [Either.Right] containing all the right values.
  */
-inline fun <reified A, reified B> List<Either<A, B>>.sequence(): Either<List<A>, List<B>> {
-   val `as` = filterIsInstance<A>()
-   val bs = filterIsInstance<B>()
-   return if (`as`.isEmpty()) bs.right() else `as`.left()
+fun <A, B> List<Either<A, B>>.sequence(): Either<List<A>, List<B>> {
+   val lefts = filterIsInstance<Either.Left<A>>().map { it.a }
+   return if (lefts.isEmpty()) {
+      filterIsInstance<Either.Right<B>>().map { it.b }.right()
+   } else {
+      lefts.left()
+   }
 }

--- a/src/test/kotlin/com/sksamuel/tabby/either/EitherSequenceTest.kt
+++ b/src/test/kotlin/com/sksamuel/tabby/either/EitherSequenceTest.kt
@@ -1,0 +1,29 @@
+package com.sksamuel.tabby.either
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class EitherSequenceTest : FunSpec() {
+   init {
+
+      test("sequence returns all rights when there are no lefts") {
+         val input: List<Either<String, Int>> = listOf(1.right(), 2.right(), 3.right())
+         input.sequence() shouldBe listOf(1, 2, 3).right()
+      }
+
+      test("sequence returns lefts when any element is a left") {
+         val input: List<Either<String, Int>> = listOf(1.right(), "boom".left(), 3.right(), "bang".left())
+         input.sequence() shouldBe listOf("boom", "bang").left()
+      }
+
+      test("sequence returns an empty right for an empty input") {
+         val input: List<Either<String, Int>> = emptyList()
+         input.sequence() shouldBe emptyList<Int>().right()
+      }
+
+      test("sequence returns all lefts when every element is a left") {
+         val input: List<Either<String, Int>> = listOf("a".left(), "b".left())
+         input.sequence() shouldBe listOf("a", "b").left()
+      }
+   }
+}


### PR DESCRIPTION
## Summary

`List<Either<A, B>>.sequence()` in `either/sequence.kt` was calling `filterIsInstance<A>()` / `filterIsInstance<B>()` on the receiver. The list elements are `Either<A, B>` instances, not raw `A` or `B` values, so for typical types (`Either<String, Int>`, etc.) both filters always returned empty lists. Net effect: **every input — including all-Lefts — was silently reported as an empty `Right`.** A reproduction returns `Right(b=[])` instead of the expected `Left(a=[...])`.

The fix filters on `Either.Left<A>` / `Either.Right<B>` and unwraps the contained values. The `inline`/`reified` modifiers are no longer needed and have been dropped.

The original docstring (`returns the first [Either.Left], or a List of all [Either.Right]s`) didn't match the `Either<List<A>, List<B>>` return type either. Updated the doc to describe the actual all-or-nothing semantics that the body always intended.

## Test plan

- [x] New `EitherSequenceTest` covers all-rights, mixed lefts/rights, all-lefts, and empty input
- [x] Verified the new tests fail on `master` (3 of 4 fail) and pass on this branch
- [x] `./gradlew test` is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)