### PR TITLE
Fix failIfTrue inverted condition

### DIFF
--- a/src/main/kotlin/com/sksamuel/tabby/results/booleans.kt
+++ b/src/main/kotlin/com/sksamuel/tabby/results/booleans.kt
@@ -17,14 +17,14 @@ fun Result<Boolean>.getOrFalse(): Boolean = getOrElse { false }
 
 
 fun Result<Boolean>.failIfTrue(): Result<Unit> =
-   flatMap { if (it) Result.unit() else Result.failure(NoSuchElementException()) }
+   flatMap { if (it) Result.failure(NoSuchElementException()) else Result.unit() }
 
 /**
  * If this [Result] is successful and contains the value true, returns a failed
  * result with the error given by the function [fn].
  */
 fun Result<Boolean>.failIfTrue(fn: () -> Exception): Result<Unit> =
-   flatMap { if (it) Result.unit() else Result.failure(fn()) }
+   flatMap { if (it) Result.failure(fn()) else Result.unit() }
 
 /**
  * Returns the result of this [Result] if successful, otherwise returns true.

--- a/src/test/kotlin/com/sksamuel/tabby/results/BooleansTest.kt
+++ b/src/test/kotlin/com/sksamuel/tabby/results/BooleansTest.kt
@@ -1,0 +1,44 @@
+package com.sksamuel.tabby.results
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.result.shouldBeFailure
+import io.kotest.matchers.result.shouldBeSuccess
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+class BooleansTest : FunSpec() {
+   init {
+
+      test("failIfFalse fails when the value is false") {
+         Result.success(false).failIfFalse().shouldBeFailure().shouldBeInstanceOf<NoSuchElementException>()
+      }
+
+      test("failIfFalse succeeds when the value is true") {
+         Result.success(true).failIfFalse().shouldBeSuccess()
+      }
+
+      test("failIfFalse(fn) uses the supplied exception") {
+         val expected = IllegalStateException("nope")
+         Result.success(false).failIfFalse { expected }.exceptionOrNull() shouldBe expected
+      }
+
+      test("failIfTrue fails when the value is true") {
+         Result.success(true).failIfTrue().shouldBeFailure().shouldBeInstanceOf<NoSuchElementException>()
+      }
+
+      test("failIfTrue succeeds when the value is false") {
+         Result.success(false).failIfTrue().shouldBeSuccess()
+      }
+
+      test("failIfTrue(fn) uses the supplied exception") {
+         val expected = IllegalStateException("nope")
+         Result.success(true).failIfTrue { expected }.exceptionOrNull() shouldBe expected
+      }
+
+      test("failIfTrue(fn) does not invoke fn when the value is false") {
+         var invoked = false
+         Result.success(false).failIfTrue { invoked = true; RuntimeException() }.shouldBeSuccess()
+         invoked shouldBe false
+      }
+   }
+}


### PR DESCRIPTION
## Summary

Both `Result<Boolean>.failIfTrue()` overloads in `results/booleans.kt` had the same body as `failIfFalse` — they succeeded when the value was `true` and failed when it was `false`, the opposite of what the name and docstring promise.

```diff
-fun Result<Boolean>.failIfTrue(): Result<Unit> =
-   flatMap { if (it) Result.unit() else Result.failure(NoSuchElementException()) }
+fun Result<Boolean>.failIfTrue(): Result<Unit> =
+   flatMap { if (it) Result.failure(NoSuchElementException()) else Result.unit() }
```

The docstring on the `fn` overload says "If this Result is successful and contains the value `true`, returns a failed result". Behaviour now matches.

## Test plan

- [x] New `BooleansTest` covers both `failIfTrue` and `failIfFalse`, plus a check that the supplied exception fn is not invoked on the non-failing branch
- [x] Verified the new tests fail on `master` (4 of 7 fail) and pass on this branch
- [x] `./gradlew test` is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)