### PR TITLE
Fix Schedule.exponential producing linear growth

### DIFF
--- a/src/main/kotlin/com/sksamuel/tabby/effects/schedules.kt
+++ b/src/main/kotlin/com/sksamuel/tabby/effects/schedules.kt
@@ -3,6 +3,7 @@
 package com.sksamuel.tabby.effects
 
 import com.sksamuel.tabby.effects.Decision.Halt
+import kotlin.math.pow
 import kotlin.random.Random
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
@@ -104,8 +105,15 @@ fun interface Schedule {
        */
       fun delay(duration: Duration): Schedule = Delay(duration)
 
+      /**
+       * Returns a [Schedule] that continues forever with an exponentially growing delay.
+       *
+       * The delay for iteration `n` (zero-indexed) is `duration * factor.pow(n)`.
+       * For example, `exponential(100.milliseconds, 2.0)` yields delays of
+       * 100ms, 200ms, 400ms, 800ms, ...
+       */
       fun exponential(duration: Duration, factor: Double): Schedule =
-         delay { (duration.inWholeMilliseconds * (factor * it + 1)).toLong().milliseconds }
+         delay { (duration.inWholeMilliseconds * factor.pow(it)).toLong().milliseconds }
 
       /**
        * Returns a new [Schedule] that continues forever and delays a duration calculated

--- a/src/test/kotlin/com/sksamuel/tabby/effects/ScheduleExponentialTest.kt
+++ b/src/test/kotlin/com/sksamuel/tabby/effects/ScheduleExponentialTest.kt
@@ -1,0 +1,55 @@
+package com.sksamuel.tabby.effects
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+
+class ScheduleExponentialTest : FunSpec() {
+   init {
+
+      test("Schedule.exponential should produce delays that grow by the factor each iteration") {
+         val schedule = Schedule.exponential(100.milliseconds, 2.0)
+         val delays = collectDelays(schedule, 5)
+         delays shouldBe listOf(
+            100.milliseconds,
+            200.milliseconds,
+            400.milliseconds,
+            800.milliseconds,
+            1600.milliseconds,
+         )
+      }
+
+      test("Schedule.exponential with factor 3.0 should triple the delay each iteration") {
+         val schedule = Schedule.exponential(50.milliseconds, 3.0)
+         val delays = collectDelays(schedule, 4)
+         delays shouldBe listOf(
+            50.milliseconds,
+            150.milliseconds,
+            450.milliseconds,
+            1350.milliseconds,
+         )
+      }
+
+      test("Schedule.exponential with factor 1.0 should keep the delay constant") {
+         val schedule = Schedule.exponential(75.milliseconds, 1.0)
+         val delays = collectDelays(schedule, 4)
+         delays shouldBe List(4) { 75.milliseconds }
+      }
+   }
+
+   private fun collectDelays(schedule: Schedule, n: Int): List<Duration> {
+      val out = mutableListOf<Duration>()
+      var current = schedule
+      repeat(n) {
+         when (val decision = current.decide()) {
+            is Decision.Continue -> {
+               out += decision.delay
+               current = decision.next
+            }
+            Decision.Halt -> return out
+         }
+      }
+      return out
+   }
+}


### PR DESCRIPTION
## Summary

`Schedule.exponential(duration, factor)` in `effects/schedules.kt` used the formula `duration * (factor * n + 1)`, which is **linear** in `n` with slope `factor * duration` and intercept `duration` — not exponential.

For `exponential(100.ms, 2.0)` this yielded delays of:
- iteration 0 → 100 ms
- iteration 1 → 300 ms
- iteration 2 → 500 ms
- iteration 3 → 700 ms

The standard exponential-backoff contract (matching ZIO, Resilience4j, the AWS SDK, Polly, etc.) is `duration * factor.pow(n)`:
- iteration 0 → 100 ms
- iteration 1 → 200 ms
- iteration 2 → 400 ms
- iteration 3 → 800 ms

```diff
-fun exponential(duration: Duration, factor: Double): Schedule =
-   delay { (duration.inWholeMilliseconds * (factor * it + 1)).toLong().milliseconds }
+fun exponential(duration: Duration, factor: Double): Schedule =
+   delay { (duration.inWholeMilliseconds * factor.pow(it)).toLong().milliseconds }
```

Also added a docstring describing the behaviour.

### Compatibility note

This is a behaviour change for any caller of `Schedule.exponential`, but:
- The previous behaviour did not match the function's name.
- It was not covered by tests.
- It is not referenced anywhere else in the codebase.

If anyone was relying on the linear formula, they almost certainly intended the exponential one and were silently getting wrong delays.

## Test plan

- [x] New `ScheduleExponentialTest` covers factors `1.0`, `2.0`, and `3.0` over multiple iterations
- [x] Verified the new tests fail on `master` (3 of 3 fail) and pass on this branch
- [x] `./gradlew test` is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)