### PR TITLE
Wrap close errors in Result.failure for Result.use

### DIFF
--- a/src/main/kotlin/com/sksamuel/tabby/effects/use.kt
+++ b/src/main/kotlin/com/sksamuel/tabby/effects/use.kt
@@ -10,5 +10,7 @@ import com.sksamuel.tabby.results.flatMap
  * of a successful result.
  */
 inline fun <R : AutoCloseable, A> Result<R>.use(f: (R) -> Result<A>): Result<A> {
-   return flatMap { it.use(f) }
+   return flatMap { resource ->
+      runCatching { resource.use { f(it).getOrThrow() } }
+   }
 }

--- a/src/test/kotlin/com/sksamuel/tabby/effects/UseTest.kt
+++ b/src/test/kotlin/com/sksamuel/tabby/effects/UseTest.kt
@@ -1,0 +1,54 @@
+package com.sksamuel.tabby.effects
+
+import com.sksamuel.tabby.results.success
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.result.shouldBeFailure
+import io.kotest.matchers.result.shouldBeSuccess
+import io.kotest.matchers.shouldBe
+
+class UseTest : FunSpec() {
+   init {
+
+      test("use closes the resource when f succeeds") {
+         val resource = Recorder()
+         Result.success(resource).use { Result.success("ok") }
+         resource.closed shouldBe true
+      }
+
+      test("use closes the resource when f returns a failure") {
+         val resource = Recorder()
+         Result.success(resource).use { Result.failure<String>(RuntimeException("f failed")) }
+         resource.closed shouldBe true
+      }
+
+      test("use returns the value when f succeeds and close succeeds") {
+         Result.success(Recorder()).use { "value".success() }.shouldBeSuccess() shouldBe "value"
+      }
+
+      test("use returns f's failure when f fails and close succeeds") {
+         val expected = RuntimeException("f failed")
+         val actual = Result.success(Recorder()).use { Result.failure<String>(expected) }
+         actual.exceptionOrNull() shouldBe expected
+      }
+
+      test("use returns the close error as a Result.failure when f succeeds and close throws") {
+         val closeException = RuntimeException("close failed")
+         val actual = Result.success(ThrowingOnClose(closeException)).use { "value".success() }
+         actual.shouldBeFailure()
+         actual.exceptionOrNull() shouldBe closeException
+      }
+   }
+}
+
+private class Recorder : AutoCloseable {
+   var closed: Boolean = false
+   override fun close() {
+      closed = true
+   }
+}
+
+private class ThrowingOnClose(private val ex: Throwable) : AutoCloseable {
+   override fun close() {
+      throw ex
+   }
+}


### PR DESCRIPTION
## Summary

The docstring on `Result<R : AutoCloseable>.use` in `effects/use.kt` promises:

> If closing the resource raises an error, then that error is returned in place of a successful result.

The implementation delegated straight to stdlib `AutoCloseable.use`, which **propagates close errors as thrown exceptions** when the block succeeded — meaning callers of a `Result`-returning API got a thrown `RuntimeException` instead of a `Result.failure`.

Repro:
```kotlin
class ThrowingClose : AutoCloseable { override fun close() { throw RuntimeException("close") } }

Result.success(ThrowingClose()).use { Result.success("ok") }
// before: throws RuntimeException("close")
// after:  Result.failure(RuntimeException("close"))
```

Fix wraps the resource use in `runCatching` so close errors (and any unexpected exception thrown from `f`) are captured as `Result.failure`, matching the documented contract. `f`-returned failures are still forwarded unchanged.

```diff
 inline fun <R : AutoCloseable, A> Result<R>.use(f: (R) -> Result<A>): Result<A> {
-   return flatMap { it.use(f) }
+   return flatMap { resource ->
+      runCatching { resource.use { f(it).getOrThrow() } }
+   }
 }
```

### Compatibility note

This is a behaviour change: previously close errors and unexpected exceptions thrown by `f` would escape the `Result` envelope; now they are captured. Callers that were catching those manually around `use` will still see them, just inside a `Result.failure` rather than via `try/catch`. No usages exist elsewhere in the codebase.

## Test plan

- [x] New `UseTest` covers close-on-success, close-on-failure, value forwarding, f-failure forwarding, and close-error capture
- [x] Verified the close-error test fails on `master` and passes on this branch (the other 4 cases were already correct)
- [x] `./gradlew test` is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)