### PR TITLE
Fix orElse @Deprecated ReplaceWith using wrong parameter name

### DIFF
--- a/src/main/kotlin/com/sksamuel/tabby/results/results.kt
+++ b/src/main/kotlin/com/sksamuel/tabby/results/results.kt
@@ -3,7 +3,7 @@ package com.sksamuel.tabby.results
 /**
  * If this [Result] is a failure, returns [other], otherwise returns this.
  */
-@Deprecated("use recover", ReplaceWith("recover(f)"))
+@Deprecated("use recover", ReplaceWith("recover { other }"))
 fun <A> Result<A>.orElse(other: Result<A>): Result<A> = recover { other }
 
 @Deprecated("use recover", ReplaceWith("recover(f)"))


### PR DESCRIPTION
## Summary

The `@Deprecated` annotation on `Result<A>.orElse(other: Result<A>)` in `results/results.kt` specifies `ReplaceWith("recover(f)")`, but the function's parameter is named `other`, not `f`. The IDE's quick-fix substitutes parameter names from the deprecated function — since `f` is not a parameter of this overload, applying the auto-replace yields code that references an undefined `f`.

Additionally, `recover` takes a lambda `() -> Result<A>`, so even `recover(other)` would not compile — the replacement must wrap `other` in a lambda.

```diff
-@Deprecated("use recover", ReplaceWith("recover(f)"))
+@Deprecated("use recover", ReplaceWith("recover { other }"))
 fun <A> Result<A>.orElse(other: Result<A>): Result<A> = recover { other }
```

The sibling overload `orElse(f: () -> Result<A>)` already has the correct hint and is unaffected.

## Test plan

- [x] `./gradlew compileKotlin` succeeds
- [x] No runtime behaviour change — only the deprecation hint metadata is updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)