### PR TITLE
Fix failIf @Deprecated ReplaceWith hints

### DIFF
--- a/src/main/kotlin/com/sksamuel/tabby/results/failIf.kt
+++ b/src/main/kotlin/com/sksamuel/tabby/results/failIf.kt
@@ -33,14 +33,14 @@ fun <A> Result<A>.failIf(p: (A) -> Boolean, message: String): Result<A> =
  * If this [Result] is a success, invokes the given predicate [p]. If the predicate returns true,
  * then a failed Result is returned, otherwise this is returned.
  */
-@Deprecated("Use failIf(exception, p)", ReplaceWith("failIf(exception, p)"))
+@Deprecated("Use failIf(exceptionFn, p)", ReplaceWith("failIf({ exception }, p)"))
 fun <A> Result<A>.failIf(p: (A) -> Boolean, exception: Exception): Result<A> =
-   failIf(exception, p)
+   flatMap { if (p(it)) exception.failure() else it.success() }
 
 /**
  * If this [Result] is a success, invokes the given predicate [p]. If the predicate returns true,
  * then a failed Result is returned containing the given [exception], otherwise [this] is returned.
  */
-@Deprecated("Use failIf(exceptionFn, p)", ReplaceWith("failIf(exception, p)"))
+@Deprecated("Use failIf(exceptionFn, p)", ReplaceWith("failIf({ exception }, p)"))
 inline fun <A> Result<A>.failIf(exception: Exception, p: (A) -> Boolean): Result<A> =
    flatMap { if (p(it)) exception.failure() else it.success() }


### PR DESCRIPTION
## Summary

Two of the deprecated `failIf` overloads in `results/failIf.kt` had broken `ReplaceWith` hints:

| Function | Old `ReplaceWith` | Problem |
|---|---|---|
| `failIf(exception: Exception, p)` (line 44) | `failIf(exception, p)` | Same call signature — IDE quick-fix is a **no-op** |
| `failIf(p, exception: Exception)` (line 36) | `failIf(exception, p)` | Resolves to the *other* deprecated overload — user gets chained deprecation warnings |

Both should point users at the non-deprecated lambda-taking overload `failIf(exceptionFn: (A) -> Exception, p)` (line 21). The correct replacement wraps the eager exception in a lambda:

```diff
-@Deprecated("Use failIf(exception, p)", ReplaceWith("failIf(exception, p)"))
+@Deprecated("Use failIf(exceptionFn, p)", ReplaceWith("failIf({ exception }, p)"))
 fun <A> Result<A>.failIf(p: (A) -> Boolean, exception: Exception): Result<A> = ...

-@Deprecated("Use failIf(exceptionFn, p)", ReplaceWith("failIf(exception, p)"))
+@Deprecated("Use failIf(exceptionFn, p)", ReplaceWith("failIf({ exception }, p)"))
 inline fun <A> Result<A>.failIf(exception: Exception, p: (A) -> Boolean): Result<A> = ...
```

Applying the IDE quick-fix to `result.failIf(myEx, myPred)` now correctly produces `result.failIf({ myEx }, myPred)`, which resolves to the modern non-deprecated overload.

Also inlined the body of `failIf(p, exception)` so it doesn't call the other deprecated overload internally — same runtime behaviour, just avoids an internal deprecation warning.

## Test plan

- [x] `./gradlew test` is green (no behaviour change)
- [x] No new code paths to test — only `@Deprecated` metadata and an internal call substitution

🤖 Generated with [Claude Code](https://claude.com/claude-code)