### PR TITLE
Document Tristate.getOrThrow asymmetric handling

### DIFF
--- a/src/main/kotlin/com/sksamuel/tabby/tristate/tristate.kt
+++ b/src/main/kotlin/com/sksamuel/tabby/tristate/tristate.kt
@@ -37,6 +37,14 @@ sealed class Tristate<out A> {
       Unspecified -> null
    }
 
+   /**
+    * Returns the value if this is a [Some], `null` if this is a [None], or throws an
+    * [IllegalStateException] if this is [Unspecified].
+    *
+    * Differs from [getValueOrNull] (which returns `null` for [Unspecified] too) and from
+    * [getValueOrThrow] (which throws for [None] too): [None] is treated as a legitimate
+    * absent value, while [Unspecified] is treated as a programmer error.
+    */
    fun getOrThrow(): A? = when (this) {
       is Some -> this.value
       is None -> null


### PR DESCRIPTION
## Summary

`Tristate.getOrThrow` returns `A?` and behaves differently from its neighbours:

| Function | `Some(v)` | `None` | `Unspecified` | Return type |
|---|---|---|---|---|
| `getValueOrNull` | `v` | `null` | `null` | `A?` |
| `getOrThrow` | `v` | `null` | **throws** | `A?` |
| `getValueOrThrow` | `v` | throws | throws | `A` |

The middle row is the meaningful distinction: `None` is treated as a legitimate absent value, `Unspecified` as a programmer error. But the naming alone doesn't make this clear, and the function had no docstring. Add one so future readers can rely on the contract without inferring it from the body.

No behaviour change.

## Test plan

- [x] `./gradlew compileKotlin` passes — docstring-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)