### PR TITLE
Fix MapIfTest false-predicate case using a true predicate

### DIFF
--- a/src/test/kotlin/com/sksamuel/tabby/results/MapIfTest.kt
+++ b/src/test/kotlin/com/sksamuel/tabby/results/MapIfTest.kt
@@ -12,7 +12,7 @@ class MapIfTest : FunSpec() {
       }
 
       test("mapIf should not invoke if the predicate is false") {
-         Result.success("foo").mapIf({ it == "foo" }) { "bar" }.getOrThrow() shouldBe "bar"
+         Result.success("foo").mapIf({ it == "baz" }) { "bar" }.getOrThrow() shouldBe "foo"
       }
 
       test("mapIf should not invoke for a failure") {


### PR DESCRIPTION
## Summary

The test named `mapIf should not invoke if the predicate is false` in `MapIfTest.kt` used predicate `{ it == "foo" }` against input `"foo"` — that predicate evaluates to **true**, not false. The two `mapIf` tests were therefore byte-for-byte identical:

```kotlin
test("mapIf should invoke if the predicate is true") {
   Result.success("foo").mapIf({ it == "foo" }) { "bar" }.getOrThrow() shouldBe "bar"
}

test("mapIf should not invoke if the predicate is false") {
   Result.success("foo").mapIf({ it == "foo" }) { "bar" }.getOrThrow() shouldBe "bar"  // same predicate, same assertion
}
```

The false branch wasn't actually covered. If `mapIf`'s implementation were inverted (e.g. `if (p(it)) it else f(it)`) the test would still pass.

```diff
 test("mapIf should not invoke if the predicate is false") {
-   Result.success("foo").mapIf({ it == "foo" }) { "bar" }.getOrThrow() shouldBe "bar"
+   Result.success("foo").mapIf({ it == "baz" }) { "bar" }.getOrThrow() shouldBe "foo"
 }
```

The new assertion verifies that when the predicate doesn't match, `mapIf` returns the original value unchanged.

## Test plan

- [x] `./gradlew test --tests MapIfTest` is green with the fix
- [x] Verified the test would catch a real bug (inverting the body of `mapIf` makes the new assertion fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)