### PR TITLE
Stop failIf calling its own deprecated overload

### DIFF
--- a/src/main/kotlin/com/sksamuel/tabby/results/failIf.kt
+++ b/src/main/kotlin/com/sksamuel/tabby/results/failIf.kt
@@ -5,14 +5,14 @@ package com.sksamuel.tabby.results
  * then a failed Result is returned, otherwise this is returned.
  */
 inline fun <A> Result<A>.failIf(p: (A) -> Boolean): Result<A> =
-   failIf(RuntimeException("failure"), p)
+   failIf({ RuntimeException("failure") }, p)
 
 /**
  * If this [Result] is a success, invokes the given predicate [p]. If the predicate returns true,
  * then a failed Result is returned, otherwise this is returned.
  */
 inline fun <A> Result<A>.failIf(message: String, p: (A) -> Boolean): Result<A> =
-   failIf(RuntimeException(message), p)
+   failIf({ RuntimeException(message) }, p)
 
 /**
  * If this [Result] is a success, invokes the given predicate [p]. If the predicate returns true,

--- a/src/test/kotlin/com/sksamuel/tabby/results/FailIfTest.kt
+++ b/src/test/kotlin/com/sksamuel/tabby/results/FailIfTest.kt
@@ -1,0 +1,47 @@
+package com.sksamuel.tabby.results
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.result.shouldBeFailure
+import io.kotest.matchers.result.shouldBeSuccess
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+class FailIfTest : FunSpec() {
+   init {
+
+      test("failIf(p) fails with RuntimeException(\"failure\") when predicate is true") {
+         Result.success(5).failIf { it > 0 }.shouldBeFailure()
+            .shouldBeInstanceOf<RuntimeException>()
+            .message shouldBe "failure"
+      }
+
+      test("failIf(p) succeeds unchanged when predicate is false") {
+         Result.success(5).failIf { it < 0 }.shouldBeSuccess() shouldBe 5
+      }
+
+      test("failIf(message, p) fails with the given message when predicate is true") {
+         Result.success(5).failIf("nope") { it > 0 }.shouldBeFailure()
+            .message shouldBe "nope"
+      }
+
+      test("failIf(message, p) succeeds unchanged when predicate is false") {
+         Result.success(5).failIf("nope") { it < 0 }.shouldBeSuccess() shouldBe 5
+      }
+
+      test("failIf(exceptionFn, p) uses the supplied lambda's exception") {
+         val ex = IllegalStateException("custom")
+         Result.success(5).failIf({ ex }, { it > 0 }).exceptionOrNull() shouldBe ex
+      }
+
+      test("failIf(exceptionFn, p) does NOT invoke the lambda when predicate is false") {
+         var invoked = 0
+         Result.success(5).failIf({ invoked++; RuntimeException() }, { it < 0 })
+         invoked shouldBe 0
+      }
+
+      test("failIf propagates the original failure unchanged") {
+         val original = RuntimeException("original")
+         Result.failure<Int>(original).failIf { true }.exceptionOrNull() shouldBe original
+      }
+   }
+}


### PR DESCRIPTION
## Summary

`failIf(p: (A) -> Boolean)` and `failIf(message: String, p: (A) -> Boolean)` (both **non-deprecated**) delegated internally to `failIf(exception: Exception, p)` — which is `@Deprecated`. Every build produced two warnings:

```
w: failIf.kt:8 'fun <A> Result<A>.failIf(exception: Exception, p)' is deprecated.
w: failIf.kt:15 'fun <A> Result<A>.failIf(exception: Exception, p)' is deprecated.
```

This also tied the lifecycle of two public non-deprecated APIs to a function slated for removal — when the deprecated overload eventually goes, these two break too.

Switch the internal calls to the non-deprecated lambda-taking overload `failIf(exceptionFn: (A) -> Exception, p)`:

```diff
 inline fun <A> Result<A>.failIf(p: (A) -> Boolean): Result<A> =
-   failIf(RuntimeException("failure"), p)
+   failIf({ RuntimeException("failure") }, p)

 inline fun <A> Result<A>.failIf(message: String, p: (A) -> Boolean): Result<A> =
-   failIf(RuntimeException(message), p)
+   failIf({ RuntimeException(message) }, p)
```

Same observable behaviour, no warning, and a small perf win: the `RuntimeException` is now constructed lazily — only when the predicate actually triggers. Stack-trace filling is non-trivial work and was previously paid on every call regardless of whether the failure path was taken.

The third deprecation warning (line 38) is a deprecated function calling another deprecated function — addressed by #20 and unchanged here to avoid conflicts.

## Test plan

- [x] New `FailIfTest` covers all three non-deprecated overloads: predicate-true, predicate-false, original-failure-propagation, and a laziness check on the lambda overload
- [x] After this PR, only one of the three `failIf` deprecation warnings remains (the deprecated→deprecated chain handled in #20)
- [x] `./gradlew test` is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)