### PR TITLE
Block NonEmptyList.copy() from breaking the non-empty invariant

### DIFF
--- a/src/main/kotlin/com/sksamuel/tabby/nel/nel.kt
+++ b/src/main/kotlin/com/sksamuel/tabby/nel/nel.kt
@@ -1,5 +1,6 @@
 package com.sksamuel.tabby.nel
 
+@ConsistentCopyVisibility
 data class NonEmptyList<A> private constructor(private val values: List<A>) {
 
    companion object {


### PR DESCRIPTION
## Summary

`data class NonEmptyList<A> private constructor(...)` declares a private primary constructor on purpose: the public construction paths (`invoke(a)`, `invoke(a, vararg rest)`, `nonEmptyListOf`) all require at least one element, and `unsafe(values)` is the explicit named escape hatch.

But Kotlin's auto-generated `data class` `copy()` defaults to **public** visibility regardless of the constructor's, so external callers could write:

```kotlin
val empty = NonEmptyList("foo").copy(values = emptyList())
empty.head  // throws NoSuchElementException — invariant violated
```

The compiler already warns about this:
```
w: Non-public primary constructor is exposed via the generated 'copy()' method of the 'data' class.
This will become an error in language version 2.3.
```

Adding `@ConsistentCopyVisibility` makes `copy()` inherit the constructor's visibility (private). External callers now get a compile error if they try to copy:

```
e: Cannot access 'fun copy(...): NonEmptyList<String>': it is private in 'NonEmptyList'.
```

`unsafe(values)` remains the documented way to opt out when bypassing the invariant is genuinely needed.

```diff
+@ConsistentCopyVisibility
 data class NonEmptyList<A> private constructor(private val values: List<A>) {
```

## Test plan

- [x] Verified externally `nel.copy(values = emptyList())` fails to compile after the fix (and compiled — wrongly — before)
- [x] `./gradlew test` is green — existing NEL tests (head/tail/last/take/map/flatMap) all use the public factory paths, unaffected
- [x] Compiler warning about exposed `copy()` no longer reported

🤖 Generated with [Claude Code](https://claude.com/claude-code)